### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-Kotlin Sublime Text 2 Package 
+Kotlin Sublime Text 2 Package
 =============================
 
-This is [Sumblime Text 2](http://www.sublimetext.com/) package for [Kotlin](http://kotlin.jetbrains.org/) programming language.
+This is the [Sublime Text 2](https://www.sublimetext.com/) package for the [Kotlin](https://kotlinlang.org/) programming language.
 
-![Kotlin Sublime Text 2 Pacakge Screenshoot](https://raw.github.com/vkostyukov/kotlin-sublime-package/master/scrot.png)
+![Kotlin Sublime Text 2 Package Screenshoot](https://raw.github.com/vkostyukov/kotlin-sublime-package/master/scrot.png)
 
 Overview
 --------
 
-The following modules already implemented:
+The following modules are already implemented:
 
-* Kotlin Syntax Defenition <code>Kotlin.tmLanguage</code>
+* Kotlin Syntax Definition <code>Kotlin.tmLanguage</code>
 
 Download
 --------
@@ -19,27 +19,28 @@ Download
 - Tagged zip: [kotlin-sublime-package-1.0.zip](https://github.com/vkostyukov/kotlin-sublime-package/archive/kotlin-sublime-package-1.0.zip)
 - Current zipball: [kotlin-sublime-package-master.zip](https://github.com/vkostyukov/kotlin-sublime-package/archive/master.zip)
 
-Instalation
+Installation
 -----------
 
-There are three ways to install Kotlin Sublime Package:
+There are four ways to install Kotlin Sublime Package:
 
-- Using archived package (<code>kotlin.sublime-package</code>)
-- Using version control system (GitHub)
-- Using raw files (<code>Kotlin.tmLanguage</code>) from repository tree
+1. Using archived package (<code>kotlin.sublime-package</code>)
+2. Using version control system (GitHub)
+3. Using raw files (<code>Kotlin.tmLanguage</code>) from repository tree
+4. Using [Sublime Package Control](https://packagecontrol.io/packages/Kotlin)
 
-There is [an instruction](http://sublimetext.info/docs/en/extensibility/packages.html) with detailed steps for any type of instalation.
+Here are [instructions](http://sublimetext.info/docs/en/extensibility/packages.html) with detailed steps for any type of installation.
 
 Contribution
 ------------
 
-If you want to contribute to this project, first of all you need to download the latest version of [AAAPackageDev](https://bitbucket.org/guillermooo/aaapackagedev) - useful tool for Sublime Text Packages developing. 
+If you want to contribute to this project, first of all you need to download the latest version of [AAAPackageDev](https://bitbucket.org/guillermooo/aaapackagedev) - useful tool for Sublime Text Packages developing.
 Then you can follow the tutorials:
 
-* [Syntax Defenitions](http://sublimetext.info/docs/en/extensibility/syntaxdefs.html) for changing the syntax defenition file
+* [Syntax Definitions](http://sublimetext.info/docs/en/extensibility/syntaxdefs.html) for changing the syntax definition file
 * [Snippets](http://sublimetext.info/docs/en/extensibility/snippets.html) for changing the snippet files
 
-There is also [a full documentation](http://sublimetext.info/docs/en/extensibility/extensibility.html) of Sublime Text extending.
+There is also [a full documentation](http://sublimetext.info/docs/en/extensibility/extensibility.html) for Sublime Text extensibility.
 
 The best way to contribute is to send pull-requests though GitHub interface.
 
@@ -47,8 +48,8 @@ Links
 -----
 
 * https://github.com/vkostyukov/kotlin-sublime-package
-* http://www.sublimetext.com/
-* http://kotlin.jetbrains.org/
+* https://www.sublimetext.com/
+* https://kotlinlang.org/
 
 ----
 by [Vladimir Kostyukov](http://vkostyukov.ru), 2012

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
 Kotlin Syntax Highlighter
 =============================
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ Download
 Installation
 -----------
 
-There are four ways to install Kotlin Sublime Package:
+There are four ways to install the Kotlin Sublime Package:
 
 1. Using archived package (<code>kotlin.sublime-package</code>)
 2. Using version control system (GitHub)
 3. Using raw files (<code>Kotlin.tmLanguage</code>) from repository tree
 4. Using [Sublime Package Control](https://packagecontrol.io/packages/Kotlin)
 
-Here are [instructions](http://sublimetext.info/docs/en/extensibility/packages.html) with detailed steps for any type of installation.
+Here are [instructions](http://docs.sublimetext.info/en/latest/extensibility/packages.html) with detailed steps for any type of installation.
 
 Contribution
 ------------
@@ -37,10 +37,10 @@ Contribution
 If you want to contribute to this project, first of all you need to download the latest version of [AAAPackageDev](https://bitbucket.org/guillermooo/aaapackagedev) - useful tool for Sublime Text Packages developing.
 Then you can follow the tutorials:
 
-* [Syntax Definitions](http://sublimetext.info/docs/en/extensibility/syntaxdefs.html) for changing the syntax definition file
-* [Snippets](http://sublimetext.info/docs/en/extensibility/snippets.html) for changing the snippet files
+* [Syntax Definitions](http://docs.sublimetext.info/en/latest/extensibility/syntaxdefs.html) for changing the syntax definition file
+* [Snippets](http://docs.sublimetext.info/en/latest/extensibility/snippets.html) for changing the snippet files
 
-There is also [a full documentation](http://sublimetext.info/docs/en/extensibility/extensibility.html) for Sublime Text extensibility.
+There is also [documentation](http://docs.sublimetext.info/en/latest/extensibility/extensibility.html) for extending functionality to Sublime Text.
 
 The best way to contribute is to send pull-requests though GitHub interface.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-Kotlin Sublime Text 2 Package
+Kotlin Syntax Highlighter
 =============================
 
-This is the [Sublime Text 2](https://www.sublimetext.com/) package for the [Kotlin](https://kotlinlang.org/) programming language.
+This is the [Sublime Text](https://www.sublimetext.com/) package for [Kotlin](https://kotlinlang.org/) syntax highlighting.
 
-![Kotlin Sublime Text 2 Package Screenshoot](https://raw.github.com/vkostyukov/kotlin-sublime-package/master/scrot.png)
+![Kotlin Syntax Highlighting Screenshoot](https://raw.github.com/vkostyukov/kotlin-sublime-package/master/scrot.png)
 
 Overview
 --------


### PR DESCRIPTION
This PR accomplishes the following updates to the README:
- Fix various typos
- Update majority of links to reflect new Kotlin and Sublime pages
- Rename the leading title from `Kotlin Sublime Text 2 Package` to `Kotlin Syntax Highlighter` for specificity
- Add Sublime Package Control method for installing this package
