### PR TITLE
reorder longer comparison operators first

### DIFF
--- a/Kotlin.tmLanguage
+++ b/Kotlin.tmLanguage
@@ -597,7 +597,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(==|!=|===|!==|&lt;=|&gt;=|&lt;|&gt;)</string>
+					<string>(===|!==|==|!=|&lt;=|&gt;=|&lt;|&gt;)</string>
 					<key>name</key>
 					<string>keyword.operator.comparison.kotlin</string>
 				</dict>


### PR DESCRIPTION
this makes Fira Code ligatures for these longer operators work correctly. See https://github.com/sublimehq/sublime_text/issues/4502, this seems to be an instance of that.

tested locally by unzipping, modifying, and rezipping package.